### PR TITLE
fix: resolve pinned versions

### DIFF
--- a/test/main.mo
+++ b/test/main.mo
@@ -6,6 +6,6 @@ import DB "mo:candb/CanDB";
 //import IC "ic:aaaaa-aa";
 import Ledger "ic:ryjl3-tyaaa-aaaaa-aaaba-cai";
 import Named "canister:backend";
+import Iter "mo:core@1/Iter";
 
-actor {
-}
+persistent actor {};

--- a/test/mops.toml
+++ b/test/mops.toml
@@ -4,6 +4,7 @@ prng = "0.0.5"
 splay = "https://github.com/chenyan2002/motoko-splay.git"
 base_local = "../../motoko-base"
 candb = "1.0.8"
+"core@1" = "1.0.0"
 
 [[canister]]
 name = "backend"
@@ -11,4 +12,3 @@ canister_id = "um5iw-rqaaa-aaaaq-qaaba-cai"
 
 [[canister]]
 canister_id = "ryjl3-tyaaa-aaaaa-aaaba-cai"
-


### PR DESCRIPTION
## Fix package name resolution for pinned dependencies (e.g., `core@1`)

Fixes bug where dependencies with `@` suffixes like `"core@1" = "1.0.0"` failed with "Package 'core@1' not found".

**Changes:**
- Added `dep_base()` helper to extract base package name before `@` 
- Updated mops service calls to query with base name (e.g., `"core"` instead of `"core@1"`)
- Preserved full names in lock file and moc args for correct imports like `mo:core@1/Iter`

Matches TypeScript implementation approach where the full name is kept throughout, with base name extraction only for API calls.